### PR TITLE
Fix sso_access_token to refresh_token

### DIFF
--- a/src/cloudforet/console_api_v2/interface/rest/extension/auth.py
+++ b/src/cloudforet/console_api_v2/interface/rest/extension/auth.py
@@ -89,7 +89,7 @@ class Auth(BaseAPI):
         )
         if refresh_token:
             return RedirectResponse(
-                f"{console_domain}/saml?sso_access_token={refresh_token}",
+                f"{console_domain}/saml?refresh_token={refresh_token}",
                 status_code=302,
             )
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
Previously, the scenario involved redirecting to a specific URL using `sso_access_token`. It has been modified to redirect to a specific URL by passing `refresh_token` as a query string.