### PR TITLE
Add redirection page for unauthorized case

### DIFF
--- a/src/cloudforet/console_api_v2/service/auth_service.py
+++ b/src/cloudforet/console_api_v2/service/auth_service.py
@@ -169,11 +169,10 @@ class AuthService(BaseService):
 
         if refresh_token:
             return RedirectResponse(
-                f"{console_domain}/saml?refresh_token={refresh_token}",
-                status_code=302,
+                f"{console_domain}/saml?refresh_token={refresh_token}", status_code=302
             )
-
-        return RedirectResponse(f"{console_domain}", status_code=302)
+        else:
+            return RedirectResponse(f"{console_domain}/error-page/401", status_code=302)
 
     @staticmethod
     def _get_acs_url(domain_name: str, domain_id: str) -> str:


### PR DESCRIPTION
### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
If the user does not exist in the SpaceONE console or if the ID entered in the IdP even if it is a valid ID in IdP, does not match the ID in the SpaceONE console, the user will be redirected to a 401 page.

<img width="1080" alt="스크린샷 2024-07-29 22 22 43" src="https://github.com/user-attachments/assets/486a7004-ef20-485e-b1dd-d14217defc2a">


